### PR TITLE
Chime duration writeable

### DIFF
--- a/main.js
+++ b/main.js
@@ -38,7 +38,7 @@ class UnifiProtect extends utils.Adapter {
 		this.writeables = [
 			"name",
 			"isRtspEnabled",
-            "chimeDuration",
+			"chimeDuration",
 			"ledSettings.isEnabled",
 			"osdSettings.isNameEnabled",
 			"osdSettings.isDebugEnabled",

--- a/main.js
+++ b/main.js
@@ -38,6 +38,7 @@ class UnifiProtect extends utils.Adapter {
 		this.writeables = [
 			"name",
 			"isRtspEnabled",
+            "chimeDuration",
 			"ledSettings.isEnabled",
 			"osdSettings.isNameEnabled",
 			"osdSettings.isDebugEnabled",


### PR DESCRIPTION
chimeDuration beschreibbar gemacht, um für G4 Doorbell die Einstellung ChimeType per Skript ändern zu können.

ChimeTypes via chimeDuration: 0=None, 300=Mechanical, 1000-10000=Digital.